### PR TITLE
Get name without calling constructor in FactoryContainer

### DIFF
--- a/src/factory-container.ts
+++ b/src/factory-container.ts
@@ -65,10 +65,7 @@ export class FactoryContainer {
    * @returns the factory F from the factories map on the container
    */
   public getFactory<K>(entity: Type<K>, namespaceKey = ''): EntityFactory<K> {
-    const entityInstance = new ((entity as unknown) as {
-      new (...args: any[]): any;
-    })();
-    const entityName: string = entityInstance?.constructor?.name;
+    const entityName: string = entity.name;
     if (!entityName) {
       throw new Error(`
         Unable to find constructor name for entity parameter.


### PR DESCRIPTION
#3 got my tests running, but I didn't realize there would be another constructor call blocking me from actually using the factories in the tests.

This should solve it for good, tested manually by using `yarn patch` in my project with the following diff:

```diff
diff --git a/lib/factory-container.js b/lib/factory-container.js
index 9e52b0faf4f35cf843d9b057b4537e3bf70d1ee8..e74c7761676cb1f54e0d47117ed40d311c4f4ae1 100644
--- a/lib/factory-container.js
+++ b/lib/factory-container.js
@@ -108,10 +108,8 @@ var FactoryContainer = /** @class */ (function () {
      * @returns the factory F from the factories map on the container
      */
     FactoryContainer.prototype.getFactory = function (entity, namespaceKey) {
-        var _a;
         if (namespaceKey === void 0) { namespaceKey = ''; }
-        var entityInstance = new entity();
-        var entityName = (_a = entityInstance === null || entityInstance === void 0 ? void 0 : entityInstance.constructor) === null || _a === void 0 ? void 0 : _a.name;
+        var entityName = entity.name;
         if (!entityName) {
             throw new Error("\n        Unable to find constructor name for entity parameter.\n        This is likely because you did not pass in a class.\n      ");
         }
```

I don't actually have docker set up locally to run your test suite, relying on your CI for that.